### PR TITLE
Add dev-only /portafolio redirects and robust gradient-text fallback

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -141,15 +141,29 @@
 }
 
 .bg-gradient-text {
-  @apply bg-clip-text text-transparent;
+  @apply text-foreground;
 }
 
 .bg-gradient-text-light {
-  @apply bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-indigo-500;
+  @apply text-foreground;
 }
 
 .bg-gradient-text-dark {
-  @apply bg-clip-text text-transparent bg-gradient-to-r from-blue-500 to-blue-700;
+  @apply text-foreground;
+}
+
+@supports (-webkit-background-clip: text) or (background-clip: text) {
+  .bg-gradient-text {
+    @apply bg-clip-text text-transparent;
+  }
+
+  .bg-gradient-text-light {
+    @apply bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-indigo-500;
+  }
+
+  .bg-gradient-text-dark {
+    @apply bg-clip-text text-transparent bg-gradient-to-r from-blue-500 to-blue-700;
+  }
 }
 
 /* Improved Card Styles */

--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,24 @@ const nextConfig = {
   basePath: process.env.NODE_ENV === "production" ? "/portafolio" : "",
   assetPrefix: process.env.NODE_ENV === "production" ? "/portafolio/" : "",
   trailingSlash: true,
+  async redirects() {
+    if (process.env.NODE_ENV === "production") {
+      return []
+    }
+
+    return [
+      {
+        source: "/portafolio",
+        destination: "/",
+        permanent: false,
+      },
+      {
+        source: "/portafolio/:path*",
+        destination: "/:path*",
+        permanent: false,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig
-


### PR DESCRIPTION
### Motivation
- Allow developing and previewing routes under the `/portafolio` base path locally without changing the production `basePath` setting. 
- Ensure headings remain readable on browsers that don't support `background-clip: text` by providing a visible fallback color and only applying gradients when supported.

### Description
- Update `next.config.js` to add dev-only `redirects()` that map `/portafolio` and `/portafolio/:path*` to `/` and `/:path*` respectively when `NODE_ENV !== 'production'`.
- Update `app/globals.css` to apply `text-foreground` as a fallback for `.bg-gradient-text`, `.bg-gradient-text-light`, and `.bg-gradient-text-dark` and move the original gradient rules into an `@supports (-webkit-background-clip: text) or (background-clip: text)` block so gradients are only used when supported.
- Minor formatting/newline fixes applied to `app/globals.css` while rearranging the rules.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812a4c8d8c8333a4d57ad32b242fc4)